### PR TITLE
Improve AAP login to make console and password clear; enable emulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 
 install: deploy ## installs the pattern, inits the vault and loads the secrets
 	make vault-init
-	./scripts/loadlic.yml
+	./ansible_load_aap_license.sh
 	echo "Installed"
 
 common-test:

--- a/scripts/ansible_load_aap_license.sh
+++ b/scripts/ansible_load_aap_license.sh
@@ -58,10 +58,6 @@
       set_fact:
         admin_password: '{{ admin_pw.resources[0].data.password | b64decode }}'
 
-    #- name: Debug items
-    #  debug:
-    #    msg: 'Host: {{ ansible_host }} PW: {{ admin_password }}'
-
     - name: Wait for API to become available
       retries: 20
       delay: 5
@@ -75,11 +71,7 @@
         body_format: json
         validate_certs: false
         force_basic_auth: true
-      #no_log: true
-
-    #- name: Debug api_status
-    #  debug:
-    #    msg: '{{ api_status }}'
+      no_log: true
 
     - name: Post manifest file
       uri:
@@ -92,3 +84,15 @@
         validate_certs: false
         force_basic_auth: true
       no_log: true
+
+    - name: Report AAP Endpoint
+      debug:
+        msg: 'AAP Endpoint: https://{{ ansible_host }}'
+
+    - name: Report AAP User
+      debug:
+        msg: 'AAP Admin User: admin'
+
+    - name: Report AAP Admin Password
+      debug:
+        msg: 'AAP Admin Password: {{ admin_password }}'

--- a/scripts/ansible_load_aap_license.sh
+++ b/scripts/ansible_load_aap_license.sh
@@ -24,6 +24,16 @@
       register: manifest_file
       become: false
 
+    - name: Wait for API/UI route to deploy
+      kubernetes.core.k8s_info:
+        kind: Route
+        namespace: ansible-automation-platform
+        name: controller
+      register: aap_host
+      retries: 20
+      delay: 5
+      until: aap_host.resources | length > 0
+
     - name: Retrieve API hostname for AAP
       kubernetes.core.k8s_info:
         kind: Route

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -72,6 +72,9 @@ clusterGroup:
     namespace: openshift-cnv
     project: hub
     path: charts/hub/cnv
+    overrides:
+    - name: cnv.debug.useEmulation
+      value: "true"
 
   # Only the hub cluster here - managed entities are edge nodes
   managedClusterGroups: []


### PR DESCRIPTION
Emulation for CNV allows VMs to be created with a performance penalty.

There may be more elegant ways than emulation in the long run but this at least allows us to spin up and run VMs on the cluster