### PR TITLE
Small makefile-level fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ install: deploy ## installs the pattern, inits the vault and loads the secrets
 	ansible-playbook ./scripts/ansible_load_controller.sh -e "aeg_project_repo=$(TARGET_REPO) aeg_project_branch=$(TARGET_BRANCH)"
 	echo "Installed"
 
+upgrade:
+	make vault-init
+	./common/scripts/ansible-push-vault-secrets.sh
+	./scripts/deploy_kubevirt_worker.sh
+	ansible-playbook ./scripts/ansible_load_controller.sh -e "aeg_project_repo=$(TARGET_REPO) aeg_project_branch=$(TARGET_BRANCH)"
+	echo "Upgraded"
+
 common-test:
 	make -C common -f common/Makefile test
 

--- a/common/scripts/vault-utils.sh
+++ b/common/scripts/vault-utils.sh
@@ -62,17 +62,17 @@ vault_init()
 		file=common/vault.init
 	fi
 
-	if [ -f "$file" ] && grep -q -e '^Unseal' "$file"; then
-		echo "$file already exists and contains seal secrets. We're moving it away to ${file}.bak"
-		mv -vf "${file}" "${file}.bak"
-	fi
-
 	# The vault is ready to be initialized when it is "Running" but not "ready".  Unsealing it makes it ready
 	rdy_check=`get_vault_ready`
 
 	if [ "$rdy_check" = "1/1 Running" ]; then
 		echo "Vault is already ready, exiting"
 		exit 0
+	fi
+
+	if [ -f "$file" ] && grep -q -e '^Unseal' "$file"; then
+		echo "$file already exists and contains seal secrets. We're moving it away to ${file}.bak"
+		mv -vf "${file}" "${file}.bak"
 	fi
 
 	until [ "$rdy_check" = "0/1 Running" ]


### PR DESCRIPTION
1) Provide an upgrade target (for re-running the Ansible loader with suitable overrides)
2) Make vault-init idempotent (this has potential for going into common)