### PR TITLE
Arrange it so that firefox does not start until the ignition container is listening

### DIFF
--- a/ansible/provision_kiosk.yml
+++ b/ansible/provision_kiosk.yml
@@ -11,9 +11,9 @@
     container_port_mapping: "8088:8088"
     container_extra_params: "--privileged -e GATEWAY_ADMIN_PASSWORD=redhat"
   tasks:
-    - name: Configure kiosk mode on hmi devices
-      ansible.builtin.import_role:
-        name: kiosk_mode
     - name: import container_lifecycle role
       ansible.builtin.import_role:
         name: container_lifecycle
+    - name: Configure kiosk mode on hmi devices
+      ansible.builtin.import_role:
+        name: kiosk_mode

--- a/ansible/provision_kiosk.yml
+++ b/ansible/provision_kiosk.yml
@@ -11,9 +11,9 @@
     container_port_mapping: "8088:8088"
     container_extra_params: "--privileged -e GATEWAY_ADMIN_PASSWORD=redhat"
   tasks:
-    - name: import container_lifecycle role
-      ansible.builtin.import_role:
-        name: container_lifecycle
     - name: Configure kiosk mode on hmi devices
       ansible.builtin.import_role:
         name: kiosk_mode
+    - name: import container_lifecycle role
+      ansible.builtin.import_role:
+        name: container_lifecycle

--- a/ansible/roles/kiosk_mode/files/redhat-kiosk.j2
+++ b/ansible/roles/kiosk_mode/files/redhat-kiosk.j2
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+kiosk_page="http://localhost:8088"
+
 while true; do
-    /usr/bin/firefox --kiosk http://localhost:8088 --display=:0
+	/usr/bin/curl -o /dev/null $kiosk_page 2> /dev/null
+	rc=$?
+
+	if [ "$rc" == "0" ]; then
+        /usr/bin/firefox --kiosk $kiosk_page --display=:0
+	else
+		sleep 1
+	fi
 done

--- a/ansible/roles/kiosk_mode/tasks/main.yml
+++ b/ansible/roles/kiosk_mode/tasks/main.yml
@@ -103,3 +103,6 @@
     owner: kiosk
     group: users
   notify: reboot
+
+- name: Flush handlers (will reboot if needed)
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Prevent ugly "connection refused" errors from firefox which require user intervention to clear