### PR TITLE
Update v1.0 to include fixes for secrets loading and allow use on OCP 4.11

### DIFF
--- a/ansible/ansible_configure_controller.yml
+++ b/ansible/ansible_configure_controller.yml
@@ -23,7 +23,7 @@
 
     - name: Set files fact
       ansible.builtin.set_fact:
-        manifest_file_ref: "{{ all_values['files']['ansible-automation-platform']['manifest'] }}"
+        manifest_file_ref: "{{ all_values['files']['aap-manifest'] }}"
 
     - name: Load manifest into variable
       delegate_to: localhost

--- a/common/.ansible-lint
+++ b/common/.ansible-lint
@@ -1,0 +1,3 @@
+# Vim filetype=yaml
+---
+offline: false

--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -43,6 +43,9 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-{{ .name }}.yaml"
+                      {{- range $valueFile := .extraValueFiles }}
+                      - {{ $valueFile | quote }}
+                      {{- end }}
                       parameters:
                       - name: global.repoURL
                         value: $ARGOCD_APP_SOURCE_REPO_URL
@@ -59,6 +62,13 @@ spec:
                      {{- range .helmOverrides }}
                       - name: {{ .name }}
                         value: {{ .value | quote }}
+                     {{- end }}
+                     {{- if .fileParameters }}
+                      fileParameters:
+                      {{- range .fileParameters }}
+                      - name: {{ .name }}
+                        path: {{ .path }}
+                      {{- end }}
                      {{- end }}
                   destination:
                     server: https://kubernetes.default.svc

--- a/common/ansible/roles/vault_utils/defaults/main.yml
+++ b/common/ansible/roles/vault_utils/defaults/main.yml
@@ -17,6 +17,7 @@ vault_pki_max_lease_ttl: "8760h"
 output_file: "common/pattern-vault.init"
 external_secrets_ns: golang-external-secrets
 external_secrets_sa: golang-external-secrets
+external_secrets_secret: golang-external-secrets
 # Setting this to false makes the role store the vault unseal keys and root login
 # token inside a secret in the cluster.
 # *Note* that this is fundamentally unsafe

--- a/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -27,21 +27,23 @@
     all_values: "{{ lookup('file', values_secret) | from_yaml | default({}, true) }}"
 
 - name: Check for secrets keys
-  ansible.builtin.fail:
-    msg: "Was not able to parse any secrets from file {{ values_secret }}. 'secrets:' top-level key is missing"
-  failed_when: "'secrets' not in all_values.keys()"
+  ansible.builtin.assert:
+    that:
+      - "('secrets' in all_values.keys()) or ('files' in all_values.keys())"
+    fail_msg: "Was not able to parse any secrets from file {{ values_secret }}. Either 'secrets:' or 'files:' top-level keys (or both) must exist"
 
-- name: Set secrets fact
+- name: Set secrets and file_secrets facts
   ansible.builtin.set_fact:
-    secrets: "{{ all_values['secrets'] }}"
+    secrets: "{{ all_values['secrets'] | default({}) }}"
+    file_secrets: "{{ all_values['files'] | default({}) }}"
 
 - name: Verify we have any secrets at all
   ansible.builtin.fail:
     msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
   failed_when:
-    secrets is not defined or secrets | length == 0
+    secrets | combine(file_secrets) | length == 0
 
-- name: Check the value-secret.yaml file for errors
+- name: Check the value-secret.yaml file for errors in the secrets section
   ansible.builtin.fail:
     msg: >
       "{{ item }}" is not properly formatted. Each key under 'secrets:'
@@ -54,18 +56,33 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: Check the value-secret.yaml file for errors
+- name: Validate file references in the files section of value-secret.yaml
+  ansible.builtin.stat:
+    path: '{{ file_stat.value }}'
+  register: file_values
+  loop_control:
+    loop_var: file_stat
+  loop:
+    "{{ file_secrets | dict2items }}"
+
+- name: debug file_stat
+  ansible.builtin.debug:
+    var: file_stat
+  when: debug | default(False) | bool
+
+- name: debug file_values
+  ansible.builtin.debug:
+    var: file_values
+  when: debug | default(False) | bool
+
+- name: Fail if referenced file does not exist
   ansible.builtin.fail:
     msg: >
-      "{{ item }}" is not properly formatted. Each key under 'secrets:'
-      needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
+      "file {{ item.file_stat.key }} {{ item.file_stat.value }}" must exist and be a file
   when: >
-    item.key | length == 0 or
-    item.value is not mapping
+    not item.stat.exists
   loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
+    "{{ file_values.results }}"
 
 # Detect here if we have only the following two keys under a password
 # s3.accessKey: <accessKey>
@@ -114,9 +131,15 @@
 #    and https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/core.py#L124
 # C. The \\A and \\Z match the beginning and end of a string (in case of multiline strings
 #    do not want to match every line)
-- name: Set vault commands fact
+
+- name: Set defaults for vault_cmds and secret_files_vault_cmds to prevent undefined variable errors
   ansible.builtin.set_fact:
-    vault_cmds: "{{ vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
+    vault_cmds: "{{ vault_cmds | default({}) }}"
+    secret_files_vault_cmds: "{{ secret_files_vault_cmds | default({}) }}"
+
+- name: Set secrets vault commands fact
+  ansible.builtin.set_fact:
+    vault_cmds: "{{ vault_cmds | combine({ item.key: vault_cmd}) }}"
   vars:
     vault_cmd: "vault kv put '{{ vault_path }}/{{ item.key }}'
       {{ item.value.keys() | zip(item.value.values() | map('regex_replace', '(?ms)\\A(.*)\\Z', \"'\\1'\")) | map('join', '=') | list | join(' ') }}"
@@ -125,9 +148,24 @@
   loop_control:
     label: "{{ item.key }}"
 
+- name: Set files vault commands fact
+  ansible.builtin.set_fact:
+    secret_files_vault_cmds: "{{ secret_files_vault_cmds | combine({ item.key: vault_cmd}) }}"
+  vars:
+    vault_cmd: "cat '{{ item.value }}' | oc exec -n {{ vault_ns }} {{ vault_pod }} -it -- sh -c 'vault kv put {{ vault_path }}/{{ item.key }} content=-'"
+  loop:
+    "{{ file_secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
 - name: Debug vault commands
   ansible.builtin.debug:
     msg: "{{ vault_cmds }}"
+  when: debug | default(False) | bool
+
+- name: Debug files vault commands
+  ansible.builtin.debug:
+    msg: "{{ secret_files_vault_cmds }}"
   when: debug | default(False) | bool
 
 # This step is not really needed when running make vault-init + load-secrets as
@@ -155,6 +193,16 @@
       sh -c "{{ item.value }}"
   loop:
     "{{ vault_cmds | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: not debug | default(False) | bool
+
+  # This has to be shell because of the use of stdin and pipes
+- name: Add the file secrets to the vault
+  ansible.builtin.shell: # noqa: command-instead-of-shell
+    "{{ item.value }}"
+  loop:
+    "{{ secret_files_vault_cmds | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
   when: not debug | default(False) | bool

--- a/common/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/common/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -33,34 +33,14 @@
     command: "vault auth enable -path={{ vault_hub }} kubernetes"
   when: kubernetes_enabled.rc != 0
 
-- name: Fetch "{{ external_secrets_ns }}/{{ external_secrets_sa }} secret name"
-  kubernetes.core.k8s_info:
-    kind: ServiceAccount
-    namespace: "{{ external_secrets_ns }}"
-    name: "{{ external_secrets_sa }}"
-    api_version: v1
-  register: serviceaccount
-
-# FIXME: we could bail out nicely if secrets is empty
-- name: Get "{{ external_secret_sa }} secrets"
-  ansible.builtin.set_fact:
-    secrets: "{{ serviceaccount.resources[0].secrets }}"
-
-- name: Filter secrets of "{{ external_secrets_ns }}/{{ external_secrets_sa }}"
-  ansible.builtin.set_fact:
-    secret: "{{ item.name }}"
-  when: '"golang-external-secrets-token-" in item.name'
-  loop: "{{ secrets }}"
-
-- name: Get token of the secret
+- name: Get token
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ external_secrets_ns }}"
-    name: "{{ secret }}"
+    name: "{{ external_secrets_secret }}"
     api_version: v1
   register: token_data
 
-# FIXME: we could bail out nicely if token_data is empty
 - name: Set sa_token fact
   ansible.builtin.set_fact:
     sa_token: "{{ token_data.resources[0].data.token | b64decode }}"

--- a/common/clustergroup/templates/applications.yaml
+++ b/common/clustergroup/templates/applications.yaml
@@ -1,5 +1,89 @@
 {{- $namespace := cat $.Values.global.pattern $.Values.clusterGroup.name | replace " " "-" }}
 {{- range .Values.clusterGroup.applications }}
+{{- if or (.generators) (.generatorFile) (.useGeneratorValues) (.destinationServer) (.destinationNamespace) }}
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: {{ .name }}
+  namespace: {{ $namespace }}
+  labels:
+    app: {{ .name }}
+spec:
+  {{- if .generators }}
+  generators: {{ .generators | toPrettyJson }}
+  {{- else }}
+  generators:
+    - git:
+        repoURL: {{ $.Values.global.repoURL }}
+        revision: {{ $.Values.global.targetRevision }}
+        {{- if .generatorFile }}
+        files:
+          - path: {{ .generatorFile | quote }}
+        {{- end }}
+  {{- end }}
+  template:
+    metadata:
+      name: {{ coalesce .namespace $namespace }}
+    spec:
+      project: {{ .project }}
+      {{- if .syncPolicy }}
+      syncPolicy: {{ .syncPolicy | toPrettyJson }}
+      {{- else }}
+      syncPolicy:
+        automated: {}
+      {{- end }}
+      {{- if .ignoreDifferences }}
+      ignoreDifferences: {{ .ignoreDifferences | toPrettyJson }}
+      {{- end }}
+      source:
+        repoURL: {{ coalesce .repoURL $.Values.global.repoURL }}
+        targetRevision: {{ coalesce .targetRevision $.Values.global.targetRevision }}
+        {{- if .chart }}
+        chart: {{ .chart }}
+        {{- end }}
+        {{- if .path }}
+        path: {{ .path }}
+        {{- end }}
+        {{- if .plugin }}
+        plugin: {{ .plugin }}
+        {{- end }}
+        {{- if not .kustomize }}
+        helm:
+          ignoreMissingValueFiles: true
+          valueFiles:
+            - "values.yaml"
+        {{- range .extraValueFiles }}
+            - {{ . | quote }}
+        {{- end }}
+        {{- if .useGeneratorValues }}
+          values: |-
+            {{ `{{ values }}` }}
+        {{- end }}
+          parameters:
+            - name: global.hubClusterDomain
+              value: {{ $.Values.global.hubClusterDomain }}
+            - name: global.localClusterDomain
+              value: {{ coalesce $.Values.global.localClusterDomain $.Values.global.hubClusterDomain }}
+            - name: global.repoURL
+              value: {{ $.Values.global.repoURL }}
+            - name: global.targetRevision
+              value: {{ $.Values.global.targetRevision }}
+            - name: global.namespace
+              value: {{ $.Values.global.namespace }}
+            - name: global.pattern
+              value: {{ $.Values.global.pattern }}
+        {{- range .overrides }}
+            - name: {{ .name  }}
+              value: {{ .value | quote  }}
+        {{- if .forceString }}
+              forceString: true
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      destination:
+        server: {{ coalesce .destinationServer "https://kubernetes.default.svc" }}
+        namespace: {{ coalesce .destinationNamespace .namespace $namespace }}
+{{- else }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -28,6 +112,9 @@ spec:
       valueFiles:
       - "/values-global.yaml"
       - "/values-{{ $.Values.clusterGroup.name }}.yaml"
+      {{- range $valueFile := .extraValueFiles }}
+      - {{ $valueFile | quote }}
+      {{- end }}
       # Watch the progress of https://issues.redhat.com/browse/GITOPS-891 and update accordingly
       parameters:
         - name: global.repoURL
@@ -49,6 +136,13 @@ spec:
           forceString: true
         {{- end }}
         {{- end }}
+      {{- if .fileParameters }}
+      fileParameters:
+      {{- range .fileParameters }}
+        - name: {{ .name }}
+          path: {{ .path }}
+      {{- end }}
+      {{- end }}
     {{- end }}
   {{- if .ignoreDifferences }}
   ignoreDifferences: {{ .ignoreDifferences | toPrettyJson }}
@@ -59,4 +153,5 @@ spec:
     #  selfHeal: true
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/common/golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
+++ b/common/golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
@@ -1,4 +1,13 @@
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets
+  annotations:
+    kubernetes.io/service-account.name: golang-external-secrets
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/common/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
+++ b/common/golang-external-secrets/templates/golang-external-secrets-hub-secretstore.yaml
@@ -19,6 +19,7 @@ spec:
         kubernetes:
           mountPath: {{ .Values.mountPath }}
           role: {{ .Values.mountRole }}
-          serviceAccountRef:
+          secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets
+            key: "token"

--- a/common/tests/golang-external-secrets-naked.expected.yaml
+++ b/common/tests/golang-external-secrets-naked.expected.yaml
@@ -52,6 +52,16 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     external-secrets.io/component : webhook
 ---
+# Source: golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets
+  annotations:
+    kubernetes.io/service-account.name: golang-external-secrets
+type: kubernetes.io/service-account-token
+---
 # Source: golang-external-secrets/charts/external-secrets/templates/crds/clusterexternalsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5718,9 +5728,10 @@ spec:
         kubernetes:
           mountPath: hub
           role: hub-role
-          serviceAccountRef:
+          secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets
+            key: "token"
 ---
 # Source: golang-external-secrets/charts/external-secrets/templates/validatingwebhook.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/common/tests/golang-external-secrets-normal.expected.yaml
+++ b/common/tests/golang-external-secrets-normal.expected.yaml
@@ -52,6 +52,16 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     external-secrets.io/component : webhook
 ---
+# Source: golang-external-secrets/templates/golang-external-secrets-hub-clusterrolebinding.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: golang-external-secrets
+  namespace: golang-external-secrets
+  annotations:
+    kubernetes.io/service-account.name: golang-external-secrets
+type: kubernetes.io/service-account-token
+---
 # Source: golang-external-secrets/charts/external-secrets/templates/crds/clusterexternalsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5718,9 +5728,10 @@ spec:
         kubernetes:
           mountPath: hub
           role: hub-role
-          serviceAccountRef:
+          secretRef:
             name: golang-external-secrets
             namespace: golang-external-secrets
+            key: "token"
 ---
 # Source: golang-external-secrets/charts/external-secrets/templates/validatingwebhook.yaml
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
1) Include secrets improvements from common (changes values-secret.yaml file structure to be what is documented on the upstream site)
2) Include secrets-handling improvements to allow running v1.0 on OCP 4.11 clusters (retains compatibility with 4.10 and 4.9)