### PR TITLE
Remove host_key_checking=False as it is not needed and insecure

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 display_skipped_hosts=False
 localhost_warning=False
-host_key_checking=False
 retry_files_enabled=False
 library=~/.ansible/plugins/modules:./ansible/plugins/modules:./common/ansible/plugins/modules:/usr/share/ansible/plugins/modules
 roles_path=~/.ansible/roles:./ansible/roles:./common/ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles


### PR DESCRIPTION
The same change as https://github.com/hybrid-cloud-patterns/ansible-edge-gitops/pull/65