### PR TITLE
Fixes for OCP 4.12

### DIFF
--- a/charts/hub/cnv/templates/hyperconverged.yaml
+++ b/charts/hub/cnv/templates/hyperconverged.yaml
@@ -23,7 +23,9 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     enableCommonBootImageImport: true
+{{- if .Values.sriovLiveMigration }}
     sriovLiveMigration: true
+{{- end }}
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/charts/hub/cnv/values.yaml
+++ b/charts/hub/cnv/values.yaml
@@ -4,3 +4,4 @@ cnv:
     useEmulation: false
 
 namespaceOverride: openshift-cnv
+sriovLiveMigration: false

--- a/common/.github/workflows/ansible-unittest.yml
+++ b/common/.github/workflows/ansible-unittest.yml
@@ -20,7 +20,7 @@ jobs:
     name: Ansible unit tests
     strategy:
       matrix:
-        python-version: [3.10.9]
+        python-version: [3.10.10]
     # Set the agent to run on
     runs-on: ubuntu-latest
 

--- a/common/.github/workflows/jsonschema.yaml
+++ b/common/.github/workflows/jsonschema.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Json Schema tests
     strategy:
       matrix:
-        python-version: [3.11.1]
+        python-version: [3.11.2]
     # Set the agent to run on
     runs-on: ubuntu-latest
 

--- a/common/Changes.md
+++ b/common/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## February 9, 2023
+
+* Add support for /values-<platform>.yaml and for /values-<platform>-<clusterversion>.yaml
+
 ## January 29, 2023
 
 * Stop extracting the HUB's CA via an imperative job running on the imported cluster.

--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -45,6 +45,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-{{ .name }}.yaml"
+                      - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}.yaml'
+                      - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}-{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}.yaml'
                       - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}-{{ .name }}.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -77,6 +77,10 @@
   register: encrypted
   failed_when: (encrypted.rc not in [0, 1])
 
+- name: Is found values secret file encrypted
+  ansible.builtin.debug:
+    msg: "Using {{ found_file }} to parse secrets"
+
 - name: Set encryption bool fact
   no_log: true
   ansible.builtin.set_fact:

--- a/common/clustergroup/templates/plumbing/applications.yaml
+++ b/common/clustergroup/templates/plumbing/applications.yaml
@@ -152,6 +152,10 @@ spec:
       - "/values-global.yaml"
       - "/values-{{ $.Values.clusterGroup.name }}.yaml"
       {{- if $.Values.global.clusterPlatform }}
+      - "/values-{{ $.Values.global.clusterPlatform }}.yaml"
+        {{- if $.Values.global.clusterVersion }}
+      - "/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.global.clusterVersion }}.yaml"
+        {{- end }}
       - "/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.clusterGroup.name }}.yaml"
       {{- end }}
       {{- if $.Values.global.clusterVersion }}

--- a/common/clustergroup/values.schema.json
+++ b/common/clustergroup/values.schema.json
@@ -148,7 +148,7 @@
     },
     "GlobalGit": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "The git configuration used to support Tekton pipeline tasks.",
       "properties": {
         "hostname": {

--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -4,14 +4,19 @@ if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
 fi
 
+UNSUPPORTED_PODMAN_VERSIONS="1.6 1.5"
+for i in ${UNSUPPORTED_PODMAN_VERSIONS}; do
+	# We add a space
+	if podman --version | grep -q -E "\b${i}"; then
+		echo "Unsupported podman version. We recommend >= 4.2.0"
+		podman --version
+		exit 1
+	fi
+done
+
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials
-# We bind mount the SSH_AUTH_SOCK socket if it is set, so ssh works without user prompting
-SSH_SOCK_MOUNTS=""
-if [ -n "$SSH_AUTH_SOCK" ]; then
-	SSH_SOCK_MOUNTS="-v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK} -e SSH_AUTH_SOCK=${SSH_AUTH_SOCK}"
-fi
 
 # We must pass -e KUBECONFIG *only* if it is set, otherwise we end up passing
 # KUBECONFIG="" which then will confuse ansible

--- a/common/tests/acm-industrial-edge-hub.expected.yaml
+++ b/common/tests/acm-industrial-edge-hub.expected.yaml
@@ -197,6 +197,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-factory.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-factory.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/common/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -188,6 +188,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-region-one.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-region-one.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -604,6 +604,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
@@ -694,6 +696,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -197,6 +197,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-factory.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-factory.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -188,6 +188,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-region-one.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-region-one.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -604,6 +604,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
@@ -694,6 +696,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/hub-cnv-industrial-edge-factory.expected.yaml
+++ b/tests/hub-cnv-industrial-edge-factory.expected.yaml
@@ -25,7 +25,6 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     enableCommonBootImageImport: true
-    sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/tests/hub-cnv-industrial-edge-hub.expected.yaml
+++ b/tests/hub-cnv-industrial-edge-hub.expected.yaml
@@ -25,7 +25,6 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     enableCommonBootImageImport: true
-    sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/tests/hub-cnv-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-cnv-medical-diagnosis-hub.expected.yaml
@@ -25,7 +25,6 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     enableCommonBootImageImport: true
-    sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/tests/hub-cnv-naked.expected.yaml
+++ b/tests/hub-cnv-naked.expected.yaml
@@ -25,7 +25,6 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     enableCommonBootImageImport: true
-    sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/tests/hub-cnv-normal.expected.yaml
+++ b/tests/hub-cnv-normal.expected.yaml
@@ -25,7 +25,6 @@ spec:
       renewBefore: 12h0m0s
   featureGates:
     enableCommonBootImageImport: true
-    sriovLiveMigration: true
     withHostPassthroughCPU: false
   infra: {}
   liveMigrationConfig:

--- a/values-AWS-4.12.yaml
+++ b/values-AWS-4.12.yaml
@@ -1,0 +1,4 @@
+---
+global:
+  datacenter:
+    storageClassName: gp3-csi


### PR DESCRIPTION
* Update common to enable new kinds of overrides (platform-version, which we need)
* Default storageclass on AWS for 4.12 has changed. so we now override it
* Remove explicit mention of sriovLiveMigration gate as 4.12 no longer specifies it (it's been deprecrated for a while) and 4.10 and 11 don't need it. (It's tunable so you can add override it back in if you want)