### PR TITLE
Update for OCP 4.13

### DIFF
--- a/charts/hub/openshift-data-foundations/values.yaml
+++ b/charts/hub/openshift-data-foundations/values.yaml
@@ -2,7 +2,7 @@ global:
   xraylab:
     namespace: "openshift-storage"
   datacenter:
-    storageClassName: gp2
+    storageClassName: gp3-csi
     region: us-east-1
 
 odf:

--- a/tests/hub-openshift-data-foundations-industrial-edge-factory.expected.yaml
+++ b/tests/hub-openshift-data-foundations-industrial-edge-factory.expected.yaml
@@ -43,7 +43,7 @@ rules:
       - storageclasses
     resourceNames:
       - ocs-storagecluster-ceph-rbd
-      - gp2
+      - gp3-csi
     verbs:
       - get
       - list
@@ -164,7 +164,7 @@ spec:
     dataPVCTemplate:
       metadata: {}
       spec:
-        storageClassName: gp2
+        storageClassName: gp3-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/tests/hub-openshift-data-foundations-industrial-edge-hub.expected.yaml
+++ b/tests/hub-openshift-data-foundations-industrial-edge-hub.expected.yaml
@@ -43,7 +43,7 @@ rules:
       - storageclasses
     resourceNames:
       - ocs-storagecluster-ceph-rbd
-      - gp2
+      - gp3-csi
     verbs:
       - get
       - list
@@ -164,7 +164,7 @@ spec:
     dataPVCTemplate:
       metadata: {}
       spec:
-        storageClassName: gp2
+        storageClassName: gp3-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/tests/hub-openshift-data-foundations-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-openshift-data-foundations-medical-diagnosis-hub.expected.yaml
@@ -43,7 +43,7 @@ rules:
       - storageclasses
     resourceNames:
       - ocs-storagecluster-ceph-rbd
-      - gp2
+      - gp3-csi
     verbs:
       - get
       - list
@@ -164,7 +164,7 @@ spec:
     dataPVCTemplate:
       metadata: {}
       spec:
-        storageClassName: gp2
+        storageClassName: gp3-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/tests/hub-openshift-data-foundations-naked.expected.yaml
+++ b/tests/hub-openshift-data-foundations-naked.expected.yaml
@@ -43,7 +43,7 @@ rules:
       - storageclasses
     resourceNames:
       - ocs-storagecluster-ceph-rbd
-      - gp2
+      - gp3-csi
     verbs:
       - get
       - list
@@ -164,7 +164,7 @@ spec:
     dataPVCTemplate:
       metadata: {}
       spec:
-        storageClassName: gp2
+        storageClassName: gp3-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/tests/hub-openshift-data-foundations-normal.expected.yaml
+++ b/tests/hub-openshift-data-foundations-normal.expected.yaml
@@ -43,7 +43,7 @@ rules:
       - storageclasses
     resourceNames:
       - ocs-storagecluster-ceph-rbd
-      - gp2
+      - gp3-csi
     verbs:
       - get
       - list
@@ -164,7 +164,7 @@ spec:
     dataPVCTemplate:
       metadata: {}
       spec:
-        storageClassName: gp2
+        storageClassName: gp3-csi
         accessModes:
         - ReadWriteOnce
         volumeMode: Block

--- a/values-AWS-4.10.yaml
+++ b/values-AWS-4.10.yaml
@@ -1,0 +1,1 @@
+values-AWS-4.11.yaml

--- a/values-AWS-4.11.yaml
+++ b/values-AWS-4.11.yaml
@@ -1,0 +1,4 @@
+---
+global:
+  datacenter:
+    storageClassName: gp2

--- a/values-AWS-4.12.yaml
+++ b/values-AWS-4.12.yaml
@@ -1,4 +1,0 @@
----
-global:
-  datacenter:
-    storageClassName: gp3-csi

--- a/values-AWS-4.13.yaml
+++ b/values-AWS-4.13.yaml
@@ -1,0 +1,1 @@
+values-AWS-4.12.yaml

--- a/values-AWS-4.13.yaml
+++ b/values-AWS-4.13.yaml
@@ -1,1 +1,0 @@
-values-AWS-4.12.yaml


### PR DESCRIPTION
1) Invert overrides (so gp3-csi is now the default and 4.10 and 4.11 are the exceptions)